### PR TITLE
forward in and forward out in compiler can now contain arrays which w…

### DIFF
--- a/src/config/CompilerConfig.json
+++ b/src/config/CompilerConfig.json
@@ -17,6 +17,20 @@
       "forward_out": [{ "name": "output", "node_output": "out" }]
     }
   },
+  "cat": {
+    "imports": ["torch"],
+    "forward": {
+      "name": "torch.cat",
+      "forward_in": [
+        [
+          { "name": "input", "node_input": "in1", "keyword": false },
+          { "name": "input", "node_input": "in2", "keyword": false }
+        ],
+        { "name": "dim", "property": "dim", "keyword": true, "default": 0 }
+      ],
+      "forward_out": [{ "name": "output", "node_output": "out" }]
+    }
+  },
   "matmul": {
     "imports": ["torch"],
     "forward": {
@@ -895,11 +909,17 @@
       "name": "TBD",
       "forward_in": [
         { "name": "input", "node_input": "in", "keyword": false },
-        { "name": "(h_0, c_0)", "node_input": "(h_0, c_0)", "keyword": false }
+        [
+          { "name": "h_0", "node_input": "h_0", "keyword": false },
+          { "name": "c_0", "node_input": "c_0", "keyword": false }
+        ]
       ],
       "forward_out": [
         { "name": "output", "node_output": "out" },
-        { "name": "output", "node_output": "(h_n, c_n)" }
+        [
+          { "name": "h_n", "node_output": "h_n" },
+          { "name": "c_n", "node_output": "c_n" }
+        ]
       ]
     }
   },

--- a/src/config/CompilerConfig.ts
+++ b/src/config/CompilerConfig.ts
@@ -27,8 +27,8 @@ export interface CompilerConfigInitParameters {
 
 export interface CompilerConfigForward {
   name: string;
-  forward_in: CompilerConfigForwardInput[];
-  forward_out: CompilerConfigForwardOutput[];
+  forward_in: (CompilerConfigForwardInput | CompilerConfigForwardInput[])[];
+  forward_out: (CompilerConfigForwardOutput | CompilerConfigForwardOutput[])[];
 }
 
 export interface CompilerConfigForwardInput {

--- a/src/config/NodeConfig.json
+++ b/src/config/NodeConfig.json
@@ -80,6 +80,36 @@
       }
     },
     {
+      "name": "cat",
+      "type": "diagram",
+      "menus": ["operations"],
+      "definition": {
+        "style": {
+          "--theme-node-background-color": "#dba2a2",
+          "--theme-node-title-color": "#ba7d7d"
+        },
+        "inputs": [
+          { "name": "in1", "label": "" },
+          { "name": "in2", "label": "" }
+        ],
+        "outputs": [
+          {
+            "name": "out",
+            "label": ""
+          }
+        ],
+        "properties": [
+          {
+            "name": "dim",
+            "label": "dim",
+            "type": "string",
+            "inputStyle": { "width": "24px" },
+            "default": 0
+          }
+        ]
+      }
+    },
+    {
       "name": "matmul",
       "type": "icon",
       "menus": ["operations"],
@@ -1221,11 +1251,13 @@
         },
         "inputs": [
           { "name": "in", "label": "inp" },
-          { "name": "(h_0, c_0)", "label": "(h_0, c_0)" }
+          { "name": "h_0", "label": "h_0" },
+          { "name": "c_0", "label": "c_0" }
         ],
         "outputs": [
           { "name": "out", "label": "out" },
-          { "name": "(h_n, c_n)", "label": "(h_n, c_n)" }
+          { "name": "h_n", "label": "h_n" },
+          { "name": "c_n", "label": "c_n" }
         ],
         "properties": [
           {


### PR DESCRIPTION
…ill be grouped as tuples in module inputs and outputs. Applied the appropriate fixes to LSTM and implemented torch.cat using the new logic